### PR TITLE
Fix: Players can use buckets in adventure gamemode

### DIFF
--- a/src/main/java/org/cloudburstmc/server/item/behavior/ItemBucket.java
+++ b/src/main/java/org/cloudburstmc/server/item/behavior/ItemBucket.java
@@ -84,6 +84,9 @@ public class ItemBucket extends Item {
 
     @Override
     public boolean onActivate(Level level, Player player, Block block, Block target, Direction face, Vector3f clickPos) {
+        if (player.isAdventure()) {
+            return false;
+        }
         BlockState bucketContents = BlockState.get(getBlockIdFromDamage(this.getMeta()));
 
         if (bucketContents == BlockStates.AIR) {


### PR DESCRIPTION
This commit stops players using buckets in the adventure gamemode.