### PR TITLE
Fix projectiles not decrementing in adventure game mode

### DIFF
--- a/src/main/java/org/cloudburstmc/server/item/behavior/ItemBow.java
+++ b/src/main/java/org/cloudburstmc/server/item/behavior/ItemBow.java
@@ -48,7 +48,7 @@ public class ItemBow extends ItemTool {
     public boolean onRelease(Player player, int ticksUsed) {
         Item itemArrow = Item.get(ARROW, 0, 1);
 
-        if (player.isSurvival() && !player.getInventory().contains(itemArrow)) {
+        if ((player.isAdventure() || player.isSurvival()) && !player.getInventory().contains(itemArrow)) {
             player.getInventory().sendContents(player);
             return false;
         }
@@ -101,7 +101,7 @@ public class ItemBow extends ItemTool {
             if (infinity && (projectile = entityShootBowEvent.getProjectile()) instanceof Arrow) {
                 ((EntityArrow) projectile).setPickupMode(EntityArrow.PICKUP_CREATIVE);
             }
-            if (player.isSurvival()) {
+            if (player.isAdventure() || player.isSurvival()) {
                 if (!infinity) {
                     player.getInventory().removeItem(itemArrow);
                 }

--- a/src/main/java/org/cloudburstmc/server/player/handler/PlayerPacketHandler.java
+++ b/src/main/java/org/cloudburstmc/server/player/handler/PlayerPacketHandler.java
@@ -1019,7 +1019,7 @@ public class PlayerPacketHandler implements BedrockPacketHandler {
                         }
 
                         if (serverItem.onClickAir(player, directionVector)) {
-                            if (player.isSurvival()) {
+                            if (player.isAdventure() || player.isSurvival()) {
                                 player.getInventory().setItemInHand(serverItem);
                             }
 


### PR DESCRIPTION
This fixes projectiles not decrementing in adventure game mode, so that includes arrows, snowballs, eggs and splash potions etc.