### PR TITLE
Remove platform from VoidGenerator by default

### DIFF
--- a/src/main/java/org/cloudburstmc/server/level/generator/impl/VoidGenerator.java
+++ b/src/main/java/org/cloudburstmc/server/level/generator/impl/VoidGenerator.java
@@ -15,18 +15,22 @@ import org.cloudburstmc.server.utils.Identifier;
 public final class VoidGenerator implements Generator {
     public static final Identifier ID = Identifier.from("minecraft", "void");
 
+    private final boolean enablePlatform;
+
     public VoidGenerator(long seed, String options) {
-        //no-op
+        this.enablePlatform = options.equals("enablePlatform");
     }
 
     @Override
     public void generate(PRandom random, IChunk chunk, int chunkX, int chunkZ) {
-        int i = chunkX | chunkZ;
-        if (((i | (i >> 31)) & ~1) == 0) {
-            //both chunk coordinates are either 0 or 1
-            for (int x = 0; x < 16; x++) {
-                for (int z = 0; z < 16; z++) {
-                    chunk.setBlock(x, 64, z, 0, BlockStates.STONE);
+        if (enablePlatform) {
+            int i = chunkX | chunkZ;
+            if (((i | (i >> 31)) & ~1) == 0) {
+                //both chunk coordinates are either 0 or 1
+                for (int x = 0; x < 16; x++) {
+                    for (int z = 0; z < 16; z++) {
+                        chunk.setBlock(x, 64, z, 0, BlockStates.STONE);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This disables the stone platform generated using the VoidGenerator unless the generator options are `enablePlatform`.