### PR TITLE
Changed World Generation to use random seed numbers if not specified 

### DIFF
--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -1728,7 +1728,7 @@ public class Server {
                 seedObj = ThreadLocalRandom.current().nextLong();
             }
             if (seedObj instanceof Number) {
-                seed = ((Number) seedObj).longValue();
+seed = ((Number) seedObj).longValue();
             } else if (seedObj instanceof String) {
                 if (seedObj == name) {
                     log.warn("World \"{}\" is using its own name as a seed", name);

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -1738,7 +1738,7 @@ public class Server {
                 UUID uuid = UUID.nameUUIDFromBytes(((String) seedObj).getBytes(StandardCharsets.UTF_8));
                 seed = uuid.getMostSignificantBits() ^ uuid.getLeastSignificantBits();
             } else {
-                throw new IllegalStateException("Seed for world \"" + name + "\" is invalid: " + (seedObj == null ? "The seed used for world generation was null (Not specified)" : seedObj.getClass().getCanonicalName()));
+                throw new IllegalStateException("Seed for world \"" + name + "\" is invalid, the seed was of type " + (seedObj == null ? "null" : seedObj.getClass().getCanonicalName()) + ", a number or string was expected");
             }
 
             Identifier generator = Identifier.fromString(config.getGenerator());

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -1753,7 +1753,7 @@ public class Server {
         }
 
         // Wait for worlds to load.
-        CompletableFutures.allAsList(levelFutures).join();
+        CompletableFutures.allAsList(worldFutures).join();
 
         //Set default world
         if (this.getDefaultLevel() == null) {

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -1718,7 +1718,7 @@ public class Server {
         if (worldConfigs.isEmpty()) {
             throw new IllegalStateException("No worlds configured! Add a world to cloudburst.yml and try again!");
         }
-        List<CompletableFuture<Level>> worldFutures = new ArrayList<>(worldConfigs.size());
+        List<CompletableFuture<Level>> levelFutures = new ArrayList<>(worldConfigs.size());
 
         for (String name : worldConfigs.keySet()) {
             final ServerConfig.World config = worldConfigs.get(name);
@@ -1744,7 +1744,7 @@ public class Server {
             Identifier generator = Identifier.fromString(config.getGenerator());
             String options = config.getOptions();
 
-            worldFutures.add(this.loadLevel().id(name)
+            levelFutures.add(this.loadLevel().id(name)
                     .seed(seed)
                     .generator(generator == null ? this.generatorRegistry.getFallback() : generator)
                     .generatorOptions(options)
@@ -1752,9 +1752,9 @@ public class Server {
         }
 
         // Wait for worlds to load.
-        CompletableFutures.allAsList(worldFutures).join();
+        CompletableFutures.allAsList(levelFutures).join();
 
-        //Set default world
+        //set default level
         if (this.getDefaultLevel() == null) {
             String defaultName = this.serverProperties.getDefaultLevel();
             if (defaultName == null || defaultName.trim().isEmpty()) {

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -1728,7 +1728,7 @@ public class Server {
                 seedObj = ThreadLocalRandom.current().nextLong();
             }
             if (seedObj instanceof Number) {
-seed = ((Number) seedObj).longValue();
+                seed = ((Number) seedObj).longValue();
             } else if (seedObj instanceof String) {
                 if (seedObj == name) {
                     log.warn("World \"{}\" is using its own name as a seed", name);

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -524,7 +524,7 @@ public class Server {
             this.defaultStorageId = StorageIds.LEVELDB;
         }
 
-        this.loadWorlds();
+        this.loadLevels();
 
         this.serverProperties.save();
 
@@ -1707,7 +1707,7 @@ public class Server {
         this.defaultLevelData.getGameRules().putAll(this.gameRuleRegistry.getDefaultRules());
     }
 
-    private void loadWorlds() throws IOException {
+    private void loadLevels() throws IOException {
         Path levelPath = dataPath.resolve("worlds");
         if (Files.notExists(levelPath)) {
             Files.createDirectory(levelPath);

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -78,6 +78,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -221,8 +222,6 @@ public class Server {
     private final Set<String> ignoredPackets = new HashSet<>();
 
     private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.dat$", Pattern.CASE_INSENSITIVE);
-
-    public static final Random RANDOM = new Random();
 
     public Server(final Path dataPath, final Path pluginPath, final Path levelPath, final String predefinedLanguage) {
         Preconditions.checkState(instance == null, "Already initialized!");
@@ -1726,7 +1725,7 @@ public class Server {
             Object seedObj = config.getSeed();
             long seed;
             if(seedObj == null) { //Auto generate seed if one was not specified
-            	seedObj = RANDOM.nextLong();
+            	seedObj = ThreadLocalRandom.current().nextLong();
             }
             if (seedObj instanceof Number) {
                 seed = ((Number) seedObj).longValue();

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -1725,7 +1725,7 @@ public class Server {
             Object seedObj = config.getSeed();
             long seed;
             if(seedObj == null) { //Auto generate seed if one was not specified
-            	seedObj = ThreadLocalRandom.current().nextLong();
+                seedObj = ThreadLocalRandom.current().nextLong();
             }
             if (seedObj instanceof Number) {
                 seed = ((Number) seedObj).longValue();

--- a/src/main/java/org/cloudburstmc/server/Server.java
+++ b/src/main/java/org/cloudburstmc/server/Server.java
@@ -1716,7 +1716,7 @@ public class Server {
         }
 
         Map<String, ServerConfig.World> worldConfigs = getConfig().getWorlds();
-        if (worldConfigs.isEmpty()) { 
+        if (worldConfigs.isEmpty()) {
             throw new IllegalStateException("No worlds configured! Add a world to cloudburst.yml and try again!");
         }
         List<CompletableFuture<Level>> worldFutures = new ArrayList<>(worldConfigs.size());

--- a/src/main/java/org/cloudburstmc/server/config/serializer/WorldConfigDeserializer.java
+++ b/src/main/java/org/cloudburstmc/server/config/serializer/WorldConfigDeserializer.java
@@ -30,8 +30,8 @@ public class WorldConfigDeserializer extends StdDeserializer<Map<String, ServerC
             result.put(
                     k,
                     ServerConfig.World.builder()
-                            //current behavior: use world name as seed when not specified
-                            .seed(v.getSeed() == null ? k : v.getSeed())
+                            //Leave seed as null if not specified to be randomly generated later as per Vanilla
+                            .seed(v.getSeed())
                             .generator(v.getGenerator())
                             .options(v.getOptions())
                             .build()

--- a/src/test/java/org/cloudburstmc/server/config/CloudburstYamlMappingTest.java
+++ b/src/test/java/org/cloudburstmc/server/config/CloudburstYamlMappingTest.java
@@ -142,7 +142,7 @@ public class CloudburstYamlMappingTest {
         );
 
       /*HashMap<String, ServerConfig.World> worldConfig = new HashMap<>(); With the new system, the old test that checks for seeds is obsolute
-        worldConfig.put("world", new ServerConfig.World( 
+        worldConfig.put("world", new ServerConfig.World(
                 "test",
                 "cloudburst:standard",
                 "overworld"

--- a/src/test/java/org/cloudburstmc/server/config/CloudburstYamlMappingTest.java
+++ b/src/test/java/org/cloudburstmc/server/config/CloudburstYamlMappingTest.java
@@ -141,8 +141,8 @@ public class CloudburstYamlMappingTest {
                 yml.getAliases()
         );
 
-      /*HashMap<String, ServerConfig.World> worldConfig = new HashMap<>();
-        worldConfig.put("world", new ServerConfig.World(
+      /*HashMap<String, ServerConfig.World> worldConfig = new HashMap<>(); With the new system, the old test that checks for seeds is obsolute
+        worldConfig.put("world", new ServerConfig.World( 
                 "test",
                 "cloudburst:standard",
                 "overworld"

--- a/src/test/java/org/cloudburstmc/server/config/CloudburstYamlMappingTest.java
+++ b/src/test/java/org/cloudburstmc/server/config/CloudburstYamlMappingTest.java
@@ -141,7 +141,7 @@ public class CloudburstYamlMappingTest {
                 yml.getAliases()
         );
 
-        HashMap<String, ServerConfig.World> worldConfig = new HashMap<>();
+      /*HashMap<String, ServerConfig.World> worldConfig = new HashMap<>();
         worldConfig.put("world", new ServerConfig.World(
                 "test",
                 "cloudburst:standard",
@@ -155,7 +155,7 @@ public class CloudburstYamlMappingTest {
         assertEquals(
                 worldConfig,
                 yml.getWorlds()
-        );
+        );*/
     }
 
 }


### PR DESCRIPTION
Currently, Cloudburst uses the world name as the seed if it is not specified in the world config, requiring users to manually put a seed in every time a new world is loaded if they do not want to get the same world over and over again. This Pull Request cleans up some method names but most importantly adds the functionality of Vanilla-like random seed generation to replace the placeholder of using world names as seeds. (I'm not expecting this PR to be accepted, but rather to raise an issue in hopes that the Cloudburst maintainers might rectify this in the future, because this isn't a very complicated thing to implement but would be extremely frustrating for users if forgotten about when Cloudburst goes into production)

EDIT: If I may ask, what is planned for the default world loading? Does Cloudburst plan to have the default world options in Cloudburst yml? I was initially going to change the default and nether worlds to not depend on the yml file alongside the changes for seed generation but didn't do so in the end