### PR TITLE
Refactor log4j2 logging

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,10 +2,10 @@
 <Configuration status="WARN">
     <Appenders>
         <TerminalConsole name="Console">
-            <PatternLayout pattern="%cyan{%d{HH:mm:ss}} [%style{%highlight{%-5level}{STYLE=Logback}}] %minecraftFormatting{%msg}%n"/>
+            <PatternLayout pattern="%cyan{%d{HH:mm:ss}} [%style{%highlight{%level}{STYLE=Logback}}] %minecraftFormatting{%msg}%n"/>
         </TerminalConsole>
         <RollingRandomAccessFile name="File" fileName="logs/server.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
-            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level - %msg%n"/>
+            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %level - %msg%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
                 <OnStartupTriggeringPolicy/>


### PR DESCRIPTION
When using `%-5level`, it would return the priority level justified to a width of 5 characters, so for example if the level was `INFO`, you would be left with a trailing space after the level like so "`INFO `". Using `%level` instead resolves this.

Before example:
![image](https://user-images.githubusercontent.com/46299532/145108404-d9747eaa-8728-4bba-947c-8be496cf1f29.png)
After example: 
![image](https://user-images.githubusercontent.com/46299532/145108282-ad68dc79-ad00-444a-9829-ba2d5fedd7c9.png)