### PR TITLE
Fix compile errors preventing Cloudburst jar from compiling

### DIFF
--- a/server/src/main/java/org/cloudburstmc/server/network/NetworkUtils.java
+++ b/server/src/main/java/org/cloudburstmc/server/network/NetworkUtils.java
@@ -166,6 +166,7 @@ public class NetworkUtils {
                 item.getCount(),
                 -1, // FIXME: item.getStackNetworkId(),
                 customName == null ? "" : customName,
-                damage == null ? 0 : damage);
+                damage == null ? 0 : damage,
+                "");
     }
 }

--- a/server/src/main/java/org/cloudburstmc/server/pack/PackManager.java
+++ b/server/src/main/java/org/cloudburstmc/server/pack/PackManager.java
@@ -215,8 +215,8 @@ public class PackManager implements Closeable, ResourcePackRegistry {
         packStack.setGameVersion("*");
         for (Pack pack : packs.values()) {
             if (pack.getType() == PackType.RESOURCES) {
-                packsInfos.getResourcePackInfos().add(new ResourcePacksInfoPacket.Entry(pack.getId().toString(),
-                        pack.getVersion().toString(), pack.getSize(), "", "", "", false, false, false));
+                packsInfos.getResourcePackInfos().add(new ResourcePacksInfoPacket.Entry(pack.getId(),
+                        pack.getVersion().toString(), pack.getSize(), "", "", "", false, false, false, ""));
                 packStack.getResourcePacks().add(new ResourcePackStackPacket.Entry(pack.getId().toString(),
                         pack.getVersion().toString(), ""));
             }


### PR DESCRIPTION
Cloudburst currently cannot be compiled at all due to 2 compile errors in NetworkUtils and PackManager. This patch fixes those errors and allows Cloudburst to be compiled again. Note: This _will not_ allow you to create a runnable Cloudburst jar. The Cloudburst jar still remains broken, and will have to have a more in depth fix applied to it to function again (Coming soon)

The fixes here are simple, the constructor signatures have merely changed. ResourcePacksInfoPacket.Entry now takes a UUID directly as the first argument rather than a String version of the UUID, and has an additional cdn argument, which I set to an empty string for now. ItemStackResponseSlot now contains a profanity filtered version of the name, but seeing as we don't have a profanity filter and probably no one is going to implement one anytime soon, we'll just throw it an empty string to make the error go away. I actually wanted to implement a better fix for this since the profanity filtered name already is default initialized to an empty string, but lombok sadly isn't flexible enough and the all args constructor will demand that as an argument even if the field is already set...