### PR TITLE
feat: refine chunk block state api

### DIFF
--- a/api/src/main/java/org/cloudburstmc/api/level/chunk/Chunk.java
+++ b/api/src/main/java/org/cloudburstmc/api/level/chunk/Chunk.java
@@ -3,6 +3,7 @@ package org.cloudburstmc.api.level.chunk;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.api.block.Block;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.blockentity.BlockEntity;
 import org.cloudburstmc.api.entity.Entity;
@@ -25,23 +26,23 @@ public interface Chunk extends Comparable<Chunk> {
 
     ChunkSection[] getSections();
 
-    default BlockState getBlock(int x, int y, int z) {
-        return this.getBlock(x, y, z, 0);
+    default BlockState getBlockState(int x, int y, int z) {
+        return this.getBlockState(x, y, z, 0);
     }
 
-    BlockState getBlock(int x, int y, int z, @NonNegative int layer);
+    BlockState getBlockState(int x, int y, int z, @NonNegative int layer);
 
-    default BlockState getAndSetBlock(int x, int y, int z, BlockState blockState) {
-        return this.getAndSetBlock(x, y, z, 0, blockState);
+    default BlockState getAndSetBlockState(int x, int y, int z, BlockState blockState) {
+        return this.getAndSetBlockState(x, y, z, 0, blockState);
     }
 
-    BlockState getAndSetBlock(int x, int y, int z, @NonNegative int layer, BlockState blockState);
+    BlockState getAndSetBlockState(int x, int y, int z, @NonNegative int layer, BlockState blockState);
 
-    default void setBlock(int x, int y, int z, BlockState blockState) {
-        this.setBlock(x, y, z, 0, blockState);
+    default void setBlockState(int x, int y, int z, BlockState blockState) {
+        this.setBlockState(x, y, z, 0, blockState);
     }
 
-    void setBlock(int x, int y, int z, @NonNegative int layer, BlockState blockState);
+    void setBlockState(int x, int y, int z, @NonNegative int layer, BlockState blockState);
 
     int getBiome(int x, int y, int z);
 

--- a/api/src/main/java/org/cloudburstmc/api/level/chunk/Chunk.java
+++ b/api/src/main/java/org/cloudburstmc/api/level/chunk/Chunk.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.api.level.chunk;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.cloudburstmc.api.block.Block;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.blockentity.BlockEntity;
 import org.cloudburstmc.api.entity.Entity;
@@ -26,23 +25,56 @@ public interface Chunk extends Comparable<Chunk> {
 
     ChunkSection[] getSections();
 
+    /**
+     * Returns the primary-layer block state at chunk-local coordinates.
+     *
+     * @param x the X coordinate from {@code 0} to {@code 15}
+     * @param y the absolute Y coordinate
+     * @param z the Z coordinate from {@code 0} to {@code 15}
+     * @return the block state
+     */
     default BlockState getBlockState(int x, int y, int z) {
         return this.getBlockState(x, y, z, 0);
     }
 
+    /**
+     * Returns the block state at chunk-local coordinates and storage layer.
+     *
+     * @param x     the X coordinate from {@code 0} to {@code 15}
+     * @param y     the absolute Y coordinate
+     * @param z     the Z coordinate from {@code 0} to {@code 15}
+     * @param layer the storage layer
+     * @return the block state
+     */
     BlockState getBlockState(int x, int y, int z, @NonNegative int layer);
 
-    default BlockState getAndSetBlockState(int x, int y, int z, BlockState blockState) {
-        return this.getAndSetBlockState(x, y, z, 0, blockState);
+    /**
+     * Replaces the primary-layer block state at chunk-local coordinates.
+     *
+     * @param x          the X coordinate from {@code 0} to {@code 15}
+     * @param y          the absolute Y coordinate
+     * @param z          the Z coordinate from {@code 0} to {@code 15}
+     * @param blockState the replacement state
+     * @return the state that was previously stored
+     */
+    default BlockState setBlockState(int x, int y, int z, BlockState blockState) {
+        return this.setBlockState(x, y, z, 0, blockState);
     }
 
-    BlockState getAndSetBlockState(int x, int y, int z, @NonNegative int layer, BlockState blockState);
-
-    default void setBlockState(int x, int y, int z, BlockState blockState) {
-        this.setBlockState(x, y, z, 0, blockState);
-    }
-
-    void setBlockState(int x, int y, int z, @NonNegative int layer, BlockState blockState);
+    /**
+     * Replaces the block state at chunk-local coordinates and storage layer.
+     *
+     * <p>This mutates chunk storage directly. Use the level mutation API when
+     * block updates, events, or client notifications are required.
+     *
+     * @param x          the X coordinate from {@code 0} to {@code 15}
+     * @param y          the absolute Y coordinate
+     * @param z          the Z coordinate from {@code 0} to {@code 15}
+     * @param layer      the storage layer
+     * @param blockState the replacement state
+     * @return the state that was previously stored
+     */
+    BlockState setBlockState(int x, int y, int z, @NonNegative int layer, BlockState blockState);
 
     int getBiome(int x, int y, int z);
 

--- a/api/src/main/java/org/cloudburstmc/api/level/chunk/ChunkSection.java
+++ b/api/src/main/java/org/cloudburstmc/api/level/chunk/ChunkSection.java
@@ -3,9 +3,31 @@ package org.cloudburstmc.api.level.chunk;
 import org.cloudburstmc.api.block.BlockState;
 
 public interface ChunkSection {
-    BlockState getBlock(int x, int y, int z, int layer);
+    /**
+     * Returns the block state at section-local coordinates and storage layer.
+     *
+     * @param x     the X coordinate from {@code 0} to {@code 15}
+     * @param y     the Y coordinate from {@code 0} to {@code 15}
+     * @param z     the Z coordinate from {@code 0} to {@code 15}
+     * @param layer the storage layer
+     * @return the block state
+     */
+    BlockState getBlockState(int x, int y, int z, int layer);
 
-    void setBlock(int x, int y, int z, int layer, BlockState blockState);
+    /**
+     * Replaces the block state at section-local coordinates and storage layer.
+     *
+     * <p>This mutates section storage directly. Use the level mutation API when
+     * block updates, events, or client notifications are required.
+     *
+     * @param x          the X coordinate from {@code 0} to {@code 15}
+     * @param y          the Y coordinate from {@code 0} to {@code 15}
+     * @param z          the Z coordinate from {@code 0} to {@code 15}
+     * @param layer      the storage layer
+     * @param blockState the replacement state
+     * @return the state that was previously stored
+     */
+    BlockState setBlockState(int x, int y, int z, int layer, BlockState blockState);
 
     byte getSkyLight(int x, int y, int z);
 

--- a/server/src/main/java/org/cloudburstmc/server/level/CloudLevel.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/CloudLevel.java
@@ -987,7 +987,7 @@ public class CloudLevel implements Level {
                             Block block = new CloudBlock(
                                     this,
                                     Vector3i.from(worldX, worldY, worldZ),
-                                    new BlockState[]{state, section.getBlock(lx, ly, lz, 1)}
+                                    new BlockState[]{state, section.getBlockState(lx, ly, lz, 1)}
                             );
 
                             randomTick.execute(block, rng);
@@ -1553,7 +1553,7 @@ public class CloudLevel implements Level {
             }
         }
 
-        BlockState oldState = chunk.getAndSetBlockState(x & 0xF, y, z & 0xF, layer, state);
+        BlockState oldState = chunk.setBlockState(x & 0xF, y, z & 0xF, layer, state);
         if (oldState == state) {
             return false;
         }
@@ -1562,18 +1562,18 @@ public class CloudLevel implements Level {
             BlockState extra = chunk.getBlockState(x & 0xf, y, z & 0xf, 1);
             if (extra == BlockStates.AIR && oldState.getType().isLiquid() && LiquidState.of(oldState).isSource()
                     && canContainLiquid(state, oldState)) {
-                chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 1, oldState);
+                chunk.setBlockState(x & 0xf, y, z & 0xf, 1, oldState);
                 addBlockChange(x, y, z);
             } else if (extra.getType().isLiquid() && state == BlockStates.AIR) {
                 if (LiquidState.of(extra).isSource()) {
-                    chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 0, extra);
+                    chunk.setBlockState(x & 0xf, y, z & 0xf, 0, extra);
                     state = extra;
                 }
 
-                chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
+                chunk.setBlockState(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
                 addBlockChange(x, y, z);
             } else if (extra.getType().isLiquid() && !canContainLiquid(state, extra)) {
-                chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
+                chunk.setBlockState(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
                 addBlockChange(x, y, z);
             }
         }

--- a/server/src/main/java/org/cloudburstmc/server/level/CloudLevel.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/CloudLevel.java
@@ -730,7 +730,7 @@ public class CloudLevel implements Level {
             int chunkZ = chunk.getZ() * 16;
             Vector3f vector = this.adjustPosToNearbyEntity(Vector3f.from(chunkX + (LCG & 0xf), 0, chunkZ + (LCG >> 8 & 0xf)));
 
-            BlockType blockType = chunk.getBlock(vector.getFloorX() & 0xf, vector.getFloorY(), vector.getFloorZ() & 0xf).getType();
+            BlockType blockType = chunk.getBlockState(vector.getFloorX() & 0xf, vector.getFloorY(), vector.getFloorZ() & 0xf).getType();
             if (blockType != BlockTypes.TALL_GRASS && !blockType.isLiquid())
                 vector = vector.add(0, 1, 0);
 
@@ -1377,8 +1377,8 @@ public class CloudLevel implements Level {
 
         return new CloudBlock(this, Vector3i.from(x, y, z),
                 new BlockState[]{
-                        chunk.getBlock(x & 0xf, y, z & 0xf, 0),
-                        chunk.getBlock(x & 0xf, y, z & 0xf, 1)
+                        chunk.getBlockState(x & 0xf, y, z & 0xf, 0),
+                        chunk.getBlockState(x & 0xf, y, z & 0xf, 1)
                 }
         );
     }
@@ -1395,8 +1395,8 @@ public class CloudLevel implements Level {
         }
 
         return new CloudBlock(this, Vector3i.from(x, y, z), new BlockState[]{
-                chunk.getBlock(x & 0xf, y, z & 0xf, 0),
-                chunk.getBlock(x & 0xf, y, z & 0xf, 1)
+                chunk.getBlockState(x & 0xf, y, z & 0xf, 0),
+                chunk.getBlockState(x & 0xf, y, z & 0xf, 1)
         });
     }
 
@@ -1431,8 +1431,8 @@ public class CloudLevel implements Level {
                     int lcz = position.getZ() & 0xF;
                     int oldLevel = chunk.getBlockLight(lcx, position.getY(), lcz);
                     Block block = new CloudBlock(this, Vector3i.from(lcx, position.getY(), lcz), new BlockState[]{
-                            chunk.getBlock(lcx, position.getY(), lcz, 0),
-                            chunk.getBlock(lcx, position.getY(), lcz, 1)
+                            chunk.getBlockState(lcx, position.getY(), lcz, 0),
+                            chunk.getBlockState(lcx, position.getY(), lcz, 1)
                     });
                     int newLevel = block.getState().getLightEmission();
                     if (oldLevel != newLevel) {
@@ -1547,33 +1547,33 @@ public class CloudLevel implements Level {
 
         Chunk chunk = this.getChunk(x >> 4, z >> 4);
         if (layer == 1 && state != BlockStates.AIR) {
-            BlockState primary = chunk.getBlock(x & 0xf, y, z & 0xf);
+            BlockState primary = chunk.getBlockState(x & 0xf, y, z & 0xf);
             if (!state.getType().isLiquid() || !canContainLiquid(primary, state)) {
                 return false;
             }
         }
 
-        BlockState oldState = chunk.getAndSetBlock(x & 0xF, y, z & 0xF, layer, state);
+        BlockState oldState = chunk.getAndSetBlockState(x & 0xF, y, z & 0xF, layer, state);
         if (oldState == state) {
             return false;
         }
 
         if (layer == 0) {
-            BlockState extra = chunk.getBlock(x & 0xf, y, z & 0xf, 1);
+            BlockState extra = chunk.getBlockState(x & 0xf, y, z & 0xf, 1);
             if (extra == BlockStates.AIR && oldState.getType().isLiquid() && LiquidState.of(oldState).isSource()
                     && canContainLiquid(state, oldState)) {
-                chunk.getAndSetBlock(x & 0xf, y, z & 0xf, 1, oldState);
+                chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 1, oldState);
                 addBlockChange(x, y, z);
             } else if (extra.getType().isLiquid() && state == BlockStates.AIR) {
                 if (LiquidState.of(extra).isSource()) {
-                    chunk.getAndSetBlock(x & 0xf, y, z & 0xf, 0, extra);
+                    chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 0, extra);
                     state = extra;
                 }
 
-                chunk.getAndSetBlock(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
+                chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
                 addBlockChange(x, y, z);
             } else if (extra.getType().isLiquid() && !canContainLiquid(state, extra)) {
-                chunk.getAndSetBlock(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
+                chunk.getAndSetBlockState(x & 0xf, y, z & 0xf, 1, BlockStates.AIR);
                 addBlockChange(x, y, z);
             }
         }
@@ -1584,8 +1584,8 @@ public class CloudLevel implements Level {
 
         Vector3i position = Vector3i.from(x, y, z);
         Block newBlock = new CloudBlock(this, position, new BlockState[]{
-                layer == 0 ? state : chunk.getBlock(x & 0xf, y, z & 0xf),
-                layer == 1 ? state : chunk.getBlock(x & 0xf, y, z & 0xf, 1)
+                layer == 0 ? state : chunk.getBlockState(x & 0xf, y, z & 0xf),
+                layer == 1 ? state : chunk.getBlockState(x & 0xf, y, z & 0xf, 1)
         });
 
         if (direct) {
@@ -2454,7 +2454,7 @@ public class CloudLevel implements Level {
     @Override
     public BlockState getBlockState(int x, int y, int z, int layer) {
         Chunk chunk = this.getChunk(x >> 4, z >> 4);
-        return chunk.getBlock(x & 0x0f, y, z & 0x0f, layer);
+        return chunk.getBlockState(x & 0x0f, y, z & 0x0f, layer);
     }
 
     public int getBiomeId(int x, int y, int z) {
@@ -2721,13 +2721,13 @@ public class CloudLevel implements Level {
             return null;
         }
 
-        BlockState topBlock = chunk.getBlock(lx, motionBlockingY, lz);
+        BlockState topBlock = chunk.getBlockState(lx, motionBlockingY, lz);
         if (topBlock.is(BlockTags.LIQUID)) {
             return null;
         }
 
         for (int y = motionBlockingY; y >= getMinHeight(); y--) {
-            BlockState state = chunk.getBlock(lx, y, lz);
+            BlockState state = chunk.getBlockState(lx, y, lz);
             if (state.is(BlockTags.LIQUID)) {
                 break;
             }
@@ -2738,8 +2738,8 @@ public class CloudLevel implements Level {
             if (collisionFloor) {
                 int standY = y + 1;
                 if (standY + 1 <= 255) {
-                    BlockState feet = chunk.getBlock(lx, standY, lz);
-                    BlockState head = chunk.getBlock(lx, standY + 1, lz);
+                    BlockState feet = chunk.getBlockState(lx, standY, lz);
+                    BlockState head = chunk.getBlockState(lx, standY + 1, lz);
                     boolean feetClear = this.isSpawnSpaceClear(feet, x, standY, z);
                     boolean headClear = this.isSpawnSpaceClear(head, x, standY + 1, z);
                     if (feetClear && headClear) {
@@ -2766,8 +2766,8 @@ public class CloudLevel implements Level {
         int y = GenericMath.clamp(startY, getMinHeight(), 254);
 
         while (y < 254) {
-            BlockState feet = chunk.getBlock(lx, y, lz);
-            BlockState head = chunk.getBlock(lx, y + 1, lz);
+            BlockState feet = chunk.getBlockState(lx, y, lz);
+            BlockState head = chunk.getBlockState(lx, y + 1, lz);
             boolean feetClear = this.isSpawnSpaceClear(feet, x, y, z);
             boolean headClear = this.isSpawnSpaceClear(head, x, y + 1, z);
             if (feetClear && headClear) {
@@ -2777,8 +2777,8 @@ public class CloudLevel implements Level {
         }
 
         while (y > getMinHeight()) {
-            BlockState feet = chunk.getBlock(lx, y - 1, lz);
-            BlockState head = chunk.getBlock(lx, y, lz);
+            BlockState feet = chunk.getBlockState(lx, y - 1, lz);
+            BlockState head = chunk.getBlockState(lx, y, lz);
             boolean feetClear = this.isSpawnSpaceClear(feet, x, y - 1, z);
             boolean headClear = this.isSpawnSpaceClear(head, x, y, z);
             if (!feetClear || !headClear) {

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunk.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunk.java
@@ -9,7 +9,6 @@ import lombok.NonNull;
 import lombok.Synchronized;
 import lombok.extern.log4j.Log4j2;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.cloudburstmc.api.block.Block;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.blockentity.BlockEntity;
 import org.cloudburstmc.api.entity.Entity;

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunk.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunk.java
@@ -189,20 +189,10 @@ public final class CloudChunk implements Chunk, Closeable {
 
     @NonNull
     @Override
-    public BlockState getAndSetBlockState(int x, int y, int z, int layer, BlockState blockState) {
+    public BlockState setBlockState(int x, int y, int z, int layer, BlockState blockState) {
         this.writeLock.lock();
         try {
-            return unsafe.getAndSetBlockState(x, y, z, layer, blockState);
-        } finally {
-            this.writeLock.unlock();
-        }
-    }
-
-    @Override
-    public void setBlockState(int x, int y, int z, int layer, BlockState blockState) {
-        this.writeLock.lock();
-        try {
-            unsafe.setBlockState(x, y, z, layer, blockState);
+            return unsafe.setBlockState(x, y, z, layer, blockState);
         } finally {
             this.writeLock.unlock();
         }

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunk.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunk.java
@@ -9,6 +9,7 @@ import lombok.NonNull;
 import lombok.Synchronized;
 import lombok.extern.log4j.Log4j2;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.cloudburstmc.api.block.Block;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.blockentity.BlockEntity;
 import org.cloudburstmc.api.entity.Entity;
@@ -178,10 +179,10 @@ public final class CloudChunk implements Chunk, Closeable {
 
     @NonNull
     @Override
-    public BlockState getBlock(int x, int y, int z, int layer) {
+    public BlockState getBlockState(int x, int y, int z, int layer) {
         this.readLock.lock();
         try {
-            return unsafe.getBlock(x, y, z, layer);
+            return unsafe.getBlockState(x, y, z, layer);
         } finally {
             this.readLock.unlock();
         }
@@ -189,20 +190,20 @@ public final class CloudChunk implements Chunk, Closeable {
 
     @NonNull
     @Override
-    public BlockState getAndSetBlock(int x, int y, int z, int layer, BlockState blockState) {
+    public BlockState getAndSetBlockState(int x, int y, int z, int layer, BlockState blockState) {
         this.writeLock.lock();
         try {
-            return unsafe.getAndSetBlock(x, y, z, layer, blockState);
+            return unsafe.getAndSetBlockState(x, y, z, layer, blockState);
         } finally {
             this.writeLock.unlock();
         }
     }
 
     @Override
-    public void setBlock(int x, int y, int z, int layer, BlockState blockState) {
+    public void setBlockState(int x, int y, int z, int layer, BlockState blockState) {
         this.writeLock.lock();
         try {
-            unsafe.setBlock(x, y, z, layer, blockState);
+            unsafe.setBlockState(x, y, z, layer, blockState);
         } finally {
             this.writeLock.unlock();
         }

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunkSection.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudChunkSection.java
@@ -24,7 +24,7 @@ public class CloudChunkSection implements ChunkSection {
     private final NibbleArray skyLight;
     /**
      * Compact position index of all randomly-ticking blocks in this section.
-     * Kept in sync with {@link #tickingBlockCount} by {@link #setBlock}.
+     * Kept in sync with {@link #tickingBlockCount} by {@link #setBlockState}.
      * Used by the random-tick loop for O(1) rejection of non-ticking rolls.
      */
     private final SectionTickList tickingList;
@@ -32,7 +32,7 @@ public class CloudChunkSection implements ChunkSection {
     /**
      * Number of blocks in layer 0 of this section that have the
      * {@code CAN_RANDOM_TICK} component set to {@code true}.
-     * Maintained incrementally in {@link #setBlock}.
+     * Maintained incrementally in {@link #setBlockState}.
      */
     private short tickingBlockCount;
 
@@ -119,7 +119,7 @@ public class CloudChunkSection implements ChunkSection {
         checkElementIndex(layer, this.storage.length, "Invalid block layer");
     }
 
-    public BlockState getBlock(int x, int y, int z, int layer) {
+    public BlockState getBlockState(int x, int y, int z, int layer) {
         checkBounds(x, y, z);
         checkLayer(layer);
         return this.storage[layer].getBlock(blockIndex(x, y, z));
@@ -130,13 +130,14 @@ public class CloudChunkSection implements ChunkSection {
      * {@link #tickingBlockCount} counter and {@link #tickingList} index
      * incrementally for layer 0 only.
      */
-    public void setBlock(int x, int y, int z, int layer, BlockState blockState) {
+    public BlockState setBlockState(int x, int y, int z, int layer, BlockState blockState) {
         checkBounds(x, y, z);
         checkLayer(layer);
         int idx = blockIndex(x, y, z);
 
+        BlockState oldState = this.storage[layer].getBlock(idx);
         if (layer == 0) {
-            BlockState old = this.storage[0].getBlock(idx);
+            BlockState old = oldState;
             boolean oldTicks = canRandomTick(old);
             boolean newTicks = canRandomTick(blockState);
 
@@ -153,6 +154,7 @@ public class CloudChunkSection implements ChunkSection {
         }
 
         this.storage[layer].setBlock(idx, blockState);
+        return oldState;
     }
 
     /**

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudLockableChunk.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudLockableChunk.java
@@ -50,18 +50,18 @@ public final class CloudLockableChunk extends LockableChunk {
 
     @NonNull
     @Override
-    public BlockState getBlock(int x, int y, int z, int layer) {
-        return unsafe.getBlock(x, y, z, layer);
+    public BlockState getBlockState(int x, int y, int z, int layer) {
+        return unsafe.getBlockState(x, y, z, layer);
     }
 
     @Override
-    public BlockState getAndSetBlock(int x, int y, int z, int layer, BlockState blockState) {
-        return unsafe.getAndSetBlock(x, y, z, layer, blockState);
+    public BlockState getAndSetBlockState(int x, int y, int z, int layer, BlockState blockState) {
+        return unsafe.getAndSetBlockState(x, y, z, layer, blockState);
     }
 
     @Override
-    public void setBlock(int x, int y, int z, int layer, BlockState blockState) {
-        this.unsafe.setBlock(x, y, z, layer, blockState);
+    public void setBlockState(int x, int y, int z, int layer, BlockState blockState) {
+        this.unsafe.setBlockState(x, y, z, layer, blockState);
     }
 
     @Override

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudLockableChunk.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/CloudLockableChunk.java
@@ -55,13 +55,8 @@ public final class CloudLockableChunk extends LockableChunk {
     }
 
     @Override
-    public BlockState getAndSetBlockState(int x, int y, int z, int layer, BlockState blockState) {
-        return unsafe.getAndSetBlockState(x, y, z, layer, blockState);
-    }
-
-    @Override
-    public void setBlockState(int x, int y, int z, int layer, BlockState blockState) {
-        this.unsafe.setBlockState(x, y, z, layer, blockState);
+    public BlockState setBlockState(int x, int y, int z, int layer, BlockState blockState) {
+        return this.unsafe.setBlockState(x, y, z, layer, blockState);
     }
 
     @Override

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/UnsafeChunk.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/UnsafeChunk.java
@@ -130,7 +130,7 @@ public final class UnsafeChunk implements Chunk, Closeable {
 
     @NonNull
     @Override
-    public BlockState getBlock(int x, int y, int z, int layer) {
+    public BlockState getBlockState(int x, int y, int z, int layer) {
         checkBounds(x, y, z);
         if (this.level.isOutsideBuildHeight(y)) {
             return BlockStates.AIR;
@@ -147,14 +147,14 @@ public final class UnsafeChunk implements Chunk, Closeable {
 
     @NonNull
     @Override
-    public BlockState getAndSetBlock(int x, int y, int z, int layer, BlockState blockState) {
-        BlockState previousBlockState = this.getBlock(x, y, z, layer);
-        this.setBlock(x, y, z, layer, blockState);
+    public BlockState getAndSetBlockState(int x, int y, int z, int layer, BlockState blockState) {
+        BlockState previousBlockState = this.getBlockState(x, y, z, layer);
+        this.setBlockState(x, y, z, layer, blockState);
         return previousBlockState;
     }
 
     @Override
-    public void setBlock(int x, int y, int z, int layer, BlockState blockState) {
+    public void setBlockState(int x, int y, int z, int layer, BlockState blockState) {
         checkBounds(x, y, z);
         if (this.level.isOutsideBuildHeight(y)) {
             return;

--- a/server/src/main/java/org/cloudburstmc/server/level/chunk/UnsafeChunk.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/chunk/UnsafeChunk.java
@@ -140,36 +140,31 @@ public final class UnsafeChunk implements Chunk, Closeable {
         if (section == null) {
             blockState = BlockStates.AIR;
         } else {
-            blockState = section.getBlock(x, y & 0xf, z, layer);
+            blockState = section.getBlockState(x, y & 0xf, z, layer);
         }
         return blockState;
     }
 
     @NonNull
     @Override
-    public BlockState getAndSetBlockState(int x, int y, int z, int layer, BlockState blockState) {
-        BlockState previousBlockState = this.getBlockState(x, y, z, layer);
-        this.setBlockState(x, y, z, layer, blockState);
-        return previousBlockState;
-    }
-
-    @Override
-    public void setBlockState(int x, int y, int z, int layer, BlockState blockState) {
+    public BlockState setBlockState(int x, int y, int z, int layer, BlockState blockState) {
         checkBounds(x, y, z);
         if (this.level.isOutsideBuildHeight(y)) {
-            return;
+            return BlockStates.AIR;
         }
+
         CloudChunkSection section = this.getSection(this.level.getSectionIndex(y));
         if (section == null) {
             if (blockState.getType() == BlockTypes.AIR) {
                 // Setting air in an empty section.
-                return;
+                return BlockStates.AIR;
             }
             section = this.getOrCreateSection(this.level.getSectionIndex(y));
         }
 
-        section.setBlock(x, y & 0xf, z, layer, blockState);
+        BlockState previousBlockState = section.setBlockState(x, y & 0xf, z, layer, blockState);
         this.setDirty();
+        return previousBlockState;
     }
 
     @Override
@@ -247,7 +242,7 @@ public final class UnsafeChunk implements Chunk, Closeable {
             CloudChunkSection section = this.sections[sectionIdx];
             if (section != null) {
                 for (int y = 15; y >= 0; y--) {
-                    if (section.getBlock(x, y, z, 0) != BlockStates.AIR) {
+                    if (section.getBlockState(x, y, z, 0) != BlockStates.AIR) {
                         return ((sectionIdx + this.level.getMinSectionY()) << 4) | y;
                     }
                 }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/impl/FlatGenerator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/impl/FlatGenerator.java
@@ -45,7 +45,7 @@ public final class FlatGenerator implements Generator {
             for (int i = 0, size = layer.weight(); i < size; i++, y++) {
                 for (int x = 15; x >= 0; x--) {
                     for (int z = 15; z >= 0; z--) {
-                        chunk.setBlock(x, y, z, state);
+                        chunk.setBlockState(x, y, z, state);
                     }
                 }
             }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/impl/VoidGenerator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/impl/VoidGenerator.java
@@ -27,7 +27,7 @@ public final class VoidGenerator implements Generator {
             //both chunk coordinates are either 0 or 1
             for (int x = 0; x < 16; x++) {
                 for (int z = 0; z < 16; z++) {
-                    chunk.setBlock(x, 64, z, 0, BlockStates.STONE);
+                    chunk.setBlockState(x, 64, z, 0, BlockStates.STONE);
                 }
             }
         }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/StandardGenerator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/StandardGenerator.java
@@ -213,9 +213,9 @@ public final class StandardGenerator implements Generator {
                                 int blockZ = sectionZ * STEP_Z | stepZ;
 
                                 if (iz > 0.0d) {
-                                    chunk.setBlock(blockX, blockY, blockZ, 0, this.ground);
+                                    chunk.setBlockState(blockX, blockY, blockZ, 0, this.ground);
                                 } else if (blockY <= this.seaLevel) {
-                                    chunk.setBlock(blockX, blockY, blockZ, 0, this.sea);
+                                    chunk.setBlockState(blockX, blockY, blockZ, 0, this.sea);
                                 }
                             }
                         }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/BedrockDecorator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/BedrockDecorator.java
@@ -2,7 +2,6 @@ package org.cloudburstmc.server.level.generator.standard.generation.decorator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.chunk.Chunk;
 import org.cloudburstmc.api.util.Identifier;
@@ -36,20 +35,20 @@ public class BedrockDecorator extends AbstractGenerationPass implements Decorato
         final BlockState state = this.block.state();
 
         for (int y = this.base.min, max = this.base.max; y < max; y++) {
-            chunk.setBlock(x, y, z, 0, state);
+            chunk.setBlockState(x, y, z, 0, state);
         }
 
         if (!this.fade.empty()) {
             if (this.reverseFade) {
                 for (int y = this.fade.min, i = 1, size = this.fade.size() + 1; i < size; y++, i++) {
                     if (random.nextInt(size) < i) {
-                        chunk.setBlock(x, y, z, 0, state);
+                        chunk.setBlockState(x, y, z, 0, state);
                     }
                 }
             } else {
                 for (int y = this.fade.min, i = this.fade.size(), size = i + 1; i > 0; y++, i--) {
                     if (random.nextInt(size) < i) {
-                        chunk.setBlock(x, y, z, 0, state);
+                        chunk.setBlockState(x, y, z, 0, state);
                     }
                 }
             }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/DeepSurfaceDecorator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/DeepSurfaceDecorator.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.server.level.generator.standard.generation.decorator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.chunk.Chunk;
 import org.cloudburstmc.api.util.Identifier;
@@ -42,19 +41,19 @@ public class DeepSurfaceDecorator extends SurfaceDecorator {
         final int depth = this.getDepthNoise(chunk, random, x, z);
 
         for (int y = 255; y >= 0; y--) {
-            if (chunk.getBlock(x, y, z, 0) == this.ground) {
+            if (chunk.getBlockState(x, y, z, 0) == this.ground) {
                 PLACE:
                 if (!placed) {
                     placed = true;
                     if (y + 1 > this.seaLevel) {
                         if (y < 255 && this.cover != null) {
-                            chunk.setBlock(x, y + 1, z, 0, this.cover);
+                            chunk.setBlockState(x, y + 1, z, 0, this.cover);
                         }
-                        chunk.setBlock(x, y--, z, 0, this.top);
+                        chunk.setBlockState(x, y--, z, 0, this.top);
                     }
                     for (int i = depth - 1; i >= 0 && y >= 0; i--, y--) {
-                        if (chunk.getBlock(x, y, z, 0) == this.ground) {
-                            chunk.setBlock(x, y, z, 0, this.filler);
+                        if (chunk.getBlockState(x, y, z, 0) == this.ground) {
+                            chunk.setBlockState(x, y, z, 0, this.filler);
                         } else {
                             //we hit air prematurely, abort!
                             placed = false;
@@ -62,8 +61,8 @@ public class DeepSurfaceDecorator extends SurfaceDecorator {
                         }
                     }
                     for (int i = this.deepSize.rand(random); i >= 0 && y >= 0; i--, y--) {
-                        if (chunk.getBlock(x, y, z, 0) == this.ground) {
-                            chunk.setBlock(x, y, z, 0, this.deep);
+                        if (chunk.getBlockState(x, y, z, 0) == this.ground) {
+                            chunk.setBlockState(x, y, z, 0, this.deep);
                         } else {
                             //we hit air prematurely, abort!
                             placed = false;

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/GroundCoverDecorator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/GroundCoverDecorator.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.server.level.generator.standard.generation.decorator;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.level.chunk.Chunk;
 import org.cloudburstmc.api.util.Identifier;
 import org.cloudburstmc.server.level.generator.standard.StandardGenerator;
@@ -46,9 +45,9 @@ public class GroundCoverDecorator implements Decorator {
     @Override
     public void decorate(RandomGenerator random, Chunk chunk, int x, int z) {
         int y = chunk.getHighestBlock(x, z);
-        if (y >= 0 && y < 255 && (this.on == null || this.on.test(chunk.getBlock(x, y, z, 0)))
-                && this.replace.test(chunk.getBlock(x, y + 1, z, 0)) && random.nextDouble() < this.chance) {
-            chunk.setBlock(x, y + 1, z, 0, this.cover.selectWeighted(random));
+        if (y >= 0 && y < 255 && (this.on == null || this.on.test(chunk.getBlockState(x, y, z, 0)))
+                && this.replace.test(chunk.getBlockState(x, y + 1, z, 0)) && random.nextDouble() < this.chance) {
+            chunk.setBlockState(x, y + 1, z, 0, this.cover.selectWeighted(random));
         }
     }
 

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/MesaSurfaceDecorator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/MesaSurfaceDecorator.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import lombok.NonNull;
 import net.daporkchop.lib.noise.NoiseSource;
-import net.daporkchop.lib.random.PRandom;
 import net.daporkchop.lib.random.impl.FastPRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.chunk.Chunk;
@@ -77,8 +76,8 @@ public class MesaSurfaceDecorator extends DepthNoiseDecorator {
         final int minHeight = this.seaLevel + this.getDepthNoise(random, blockX, blockZ);
 
         for (int y = chunk.getHighestBlock(x, z); y >= minHeight; y--) {
-            if (chunk.getBlock(x, y, z, 0) == ground) {
-                chunk.setBlock(x, y, z, 0, this.getBand(blockX, y, blockZ));
+            if (chunk.getBlockState(x, y, z, 0) == ground) {
+                chunk.setBlockState(x, y, z, 0, this.getBand(blockX, y, blockZ));
             }
         }
     }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/ReplaceTopDecorator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/ReplaceTopDecorator.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.server.level.generator.standard.generation.decorator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.chunk.Chunk;
 import org.cloudburstmc.api.util.Identifier;
@@ -42,8 +41,8 @@ public class ReplaceTopDecorator implements Decorator {
     @Override
     public void decorate(RandomGenerator random, Chunk chunk, int x, int z) {
         int y = chunk.getHighestBlock(x, z);
-        if (y >= 0 && this.replace.test(chunk.getBlock(x, y, z, 0)) && this.height.contains(y)) {
-            chunk.setBlock(x, y, z, 0, this.block);
+        if (y >= 0 && this.replace.test(chunk.getBlockState(x, y, z, 0)) && this.height.contains(y)) {
+            chunk.setBlockState(x, y, z, 0, this.block);
         }
     }
 

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/ScatteredCoverDecorator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/ScatteredCoverDecorator.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.server.level.generator.standard.generation.decorator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.level.chunk.Chunk;
 import org.cloudburstmc.api.util.Identifier;
 import org.cloudburstmc.server.level.generator.standard.StandardGenerator;
@@ -51,9 +50,9 @@ public class ScatteredCoverDecorator implements Decorator {
 
         for (int y = min(chunk.getHighestBlock(x, z), 254); y >= 0; y--) {
             if (random.nextDouble() < chance
-                    && on.test(chunk.getBlock(x, y, z, 0))
-                    && replace.test(chunk.getBlock(x, y + 1, z, 0))) {
-                chunk.setBlock(x, y + 1, z, 0, block.selectWeighted(random));
+                    && on.test(chunk.getBlockState(x, y, z, 0))
+                    && replace.test(chunk.getBlockState(x, y + 1, z, 0))) {
+                chunk.setBlockState(x, y + 1, z, 0, block.selectWeighted(random));
             }
         }
     }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/SurfaceDecorator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/generation/decorator/SurfaceDecorator.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.server.level.generator.standard.generation.decorator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.chunk.Chunk;
 import org.cloudburstmc.api.util.Identifier;
@@ -56,19 +55,19 @@ public class SurfaceDecorator extends DepthNoiseDecorator {
         final int min = this.height == null ? 0 : this.height.min;
 
         for (int y = chunk.getHighestBlock(x, z); y >= min; y--) {
-            if (chunk.getBlock(x, y, z, 0) == this.ground) {
+            if (chunk.getBlockState(x, y, z, 0) == this.ground) {
                 if (!placed) {
                     placed = true;
                     if (y <= max) {
                         if (y + 1 > this.seaLevel) {
                             if (y < 255 && this.cover != null) {
-                                chunk.setBlock(x, y + 1, z, 0, this.cover);
+                                chunk.setBlockState(x, y + 1, z, 0, this.cover);
                             }
-                            chunk.setBlock(x, y--, z, 0, this.top);
+                            chunk.setBlockState(x, y--, z, 0, this.top);
                         }
                         for (int i = depth - 1; i >= 0 && y >= 0; i--, y--) {
-                            if (chunk.getBlock(x, y, z, 0) == this.ground) {
-                                chunk.setBlock(x, y, z, 0, this.filler);
+                            if (chunk.getBlockState(x, y, z, 0) == this.ground) {
+                                chunk.setBlockState(x, y, z, 0, this.filler);
                             } else {
                                 //we hit air prematurely, abort!
                                 placed = false;

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/CocoaPopulator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/CocoaPopulator.java
@@ -2,7 +2,6 @@ package org.cloudburstmc.server.level.generator.standard.population;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockStates;
 import org.cloudburstmc.api.block.BlockTraits;
 import org.cloudburstmc.api.level.ChunkManager;
@@ -52,7 +51,7 @@ public class CocoaPopulator extends ChancePopulator {
 
         final Chunk chunk = level.getChunk(blockX >> 4, blockZ >> 4);
         for (int y = this.height.min, max = this.height.max; y < max; y++) {
-            if (random.nextDouble() >= chance || !replace.test(chunk.getBlock(blockX & 0xF, y, blockZ & 0xF, 0))) {
+            if (random.nextDouble() >= chance || !replace.test(chunk.getBlockState(blockX & 0xF, y, blockZ & 0xF, 0))) {
                 continue;
             }
 

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/SubmergedOrePopulator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/SubmergedOrePopulator.java
@@ -2,7 +2,6 @@ package org.cloudburstmc.server.level.generator.standard.population;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.ChunkManager;
 import org.cloudburstmc.api.level.chunk.Chunk;
@@ -51,7 +50,7 @@ public class SubmergedOrePopulator extends ChancePopulator.Column {
         Chunk chunk = level.getChunk(blockX >> 4, blockZ >> 4);
         int y = chunk.getHighestBlock(blockX & 0xF, blockZ & 0xF);
         for (; y > 0; y--) {
-            if (this.replace.test(chunk.getBlock(blockX & 0xF, y, blockZ & 0xF, 0))) {
+            if (this.replace.test(chunk.getBlockState(blockX & 0xF, y, blockZ & 0xF, 0))) {
                 break;
             }
         }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/plant/DoublePlantPopulator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/plant/DoublePlantPopulator.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.server.level.generator.standard.population.plant;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.block.BlockStates;
 import org.cloudburstmc.api.block.BlockTraits;
@@ -56,11 +55,11 @@ public class DoublePlantPopulator extends AbstractPlantPopulator {
             int blockZ = z + random.nextInt(8) - random.nextInt(8);
 
             Chunk chunk = level.getChunk(blockX >> 4, blockZ >> 4);
-            if (on.test(chunk.getBlock(blockX & 0xF, blockY, blockZ & 0xF, 0))
-                    && replace.test(chunk.getBlock(blockX & 0xF, blockY + 1, blockZ & 0xF, 0))
-                    && replace.test(chunk.getBlock(blockX & 0xF, blockY + 2, blockZ & 0xF, 0))) {
-                chunk.setBlock(blockX & 0xF, blockY + 1, blockZ & 0xF, 0, bottom);
-                chunk.setBlock(blockX & 0xF, blockY + 2, blockZ & 0xF, 0, top);
+            if (on.test(chunk.getBlockState(blockX & 0xF, blockY, blockZ & 0xF, 0))
+                    && replace.test(chunk.getBlockState(blockX & 0xF, blockY + 1, blockZ & 0xF, 0))
+                    && replace.test(chunk.getBlockState(blockX & 0xF, blockY + 2, blockZ & 0xF, 0))) {
+                chunk.setBlockState(blockX & 0xF, blockY + 1, blockZ & 0xF, 0, bottom);
+                chunk.setBlockState(blockX & 0xF, blockY + 2, blockZ & 0xF, 0, top);
             }
         }
     }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/plant/PlantPopulator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/plant/PlantPopulator.java
@@ -2,7 +2,6 @@ package org.cloudburstmc.server.level.generator.standard.population.plant;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.ChunkManager;
 import org.cloudburstmc.api.level.chunk.Chunk;
@@ -58,7 +57,7 @@ public class PlantPopulator extends AbstractPlantPopulator {
             int blockZ = z + random.nextInt(8) - random.nextInt(8);
 
             Chunk chunk = level.getChunk(blockX >> 4, blockZ >> 4);
-            if (!on.test(chunk.getBlock(blockX & 0xF, blockY, blockZ & 0xF, 0))) {
+            if (!on.test(chunk.getBlockState(blockX & 0xF, blockY, blockZ & 0xF, 0))) {
                 continue;
             }
             if (water != null && !(water.test(level.getBlockState(blockX + 1, blockY, blockZ, 0))
@@ -67,12 +66,12 @@ public class PlantPopulator extends AbstractPlantPopulator {
                     || water.test(level.getBlockState(blockX, blockY, blockZ - 1, 0)))) {
                 continue;
             }
-            for (int dy = 1; dy <= height && replace.test(chunk.getBlock(blockX & 0xF, blockY + dy, blockZ & 0xF, 0))
+            for (int dy = 1; dy <= height && replace.test(chunk.getBlockState(blockX & 0xF, blockY + dy, blockZ & 0xF, 0))
                     && replace.test(level.getBlockState(blockX + 1, blockY + dy, blockZ, 0))
                     && replace.test(level.getBlockState(blockX - 1, blockY + dy, blockZ, 0))
                     && replace.test(level.getBlockState(blockX, blockY + dy, blockZ + 1, 0))
                     && replace.test(level.getBlockState(blockX, blockY + dy, blockZ - 1, 0)); dy++) {
-                chunk.setBlock(blockX & 0xF, blockY + dy, blockZ & 0xF, 0, block);
+                chunk.setBlockState(blockX & 0xF, blockY + dy, blockZ & 0xF, 0, block);
             }
         }
     }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/plant/ShrubPopulator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/plant/ShrubPopulator.java
@@ -2,7 +2,6 @@ package org.cloudburstmc.server.level.generator.standard.population.plant;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import tools.jackson.databind.annotation.JsonDeserialize;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.ChunkManager;
 import org.cloudburstmc.api.level.chunk.Chunk;
@@ -65,9 +64,9 @@ public class ShrubPopulator extends AbstractPlantPopulator {
             int blockZ = z + random.nextInt(8) - random.nextInt(8);
 
             Chunk chunk = level.getChunk(blockX >> 4, blockZ >> 4);
-            if (on.test(chunk.getBlock(blockX & 0xF, blockY, blockZ & 0xF, 0))
-                    && replace.test(chunk.getBlock(blockX & 0xF, blockY + 1, blockZ & 0xF, 0))) {
-                chunk.setBlock(blockX & 0xF, blockY + 1, blockZ & 0xF, 0, block);
+            if (on.test(chunk.getBlockState(blockX & 0xF, blockY, blockZ & 0xF, 0))
+                    && replace.test(chunk.getBlockState(blockX & 0xF, blockY + 1, blockZ & 0xF, 0))) {
+                chunk.setBlockState(blockX & 0xF, blockY + 1, blockZ & 0xF, 0, block);
             }
         }
     }

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/tree/AbstractTreePopulator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/tree/AbstractTreePopulator.java
@@ -1,7 +1,6 @@
 package org.cloudburstmc.server.level.generator.standard.population.tree;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.ChunkManager;
 import org.cloudburstmc.api.level.chunk.Chunk;
@@ -48,9 +47,9 @@ public abstract class AbstractTreePopulator extends ChancePopulator {
         final int min = this.height.min;
 
         Chunk chunk = level.getChunk(blockX >> 4, blockZ >> 4);
-        BlockState lastId = chunk.getBlock(blockX & 0xF, max + 1, blockZ & 0xF, 0);
+        BlockState lastId = chunk.getBlockState(blockX & 0xF, max + 1, blockZ & 0xF, 0);
         for (int y = max; y >= min; y--) {
-            BlockState id = chunk.getBlock(blockX & 0xF, y, blockZ & 0xF, 0);
+            BlockState id = chunk.getBlockState(blockX & 0xF, y, blockZ & 0xF, 0);
 
             if (replace.test(lastId) && on.test(id) && random.nextDouble() < this.chance) {
                 this.placeTree(random, level, blockX, y, blockZ);

--- a/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/tree/HugeTreePopulator.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/generator/standard/population/tree/HugeTreePopulator.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
 import lombok.NonNull;
-import net.daporkchop.lib.random.PRandom;
 import org.cloudburstmc.api.block.BlockState;
 import org.cloudburstmc.api.level.ChunkManager;
 import org.cloudburstmc.api.level.chunk.Chunk;
@@ -66,9 +65,9 @@ public class HugeTreePopulator extends AbstractTreePopulator {
             final int min = this.height.min;
 
             Chunk chunk = level.getChunk(blockX >> 4, blockZ >> 4);
-            BlockState lastId = chunk.getBlock(blockX & 0xF, max + 1, blockZ & 0xF, 0);
+            BlockState lastId = chunk.getBlockState(blockX & 0xF, max + 1, blockZ & 0xF, 0);
             for (int y = max; y >= min; y--) {
-                BlockState id = chunk.getBlock(blockX & 0xF, y, blockZ & 0xF, 0);
+                BlockState id = chunk.getBlockState(blockX & 0xF, y, blockZ & 0xF, 0);
 
                 if (replace.test(lastId) && on.test(id)) {
                     this.placeTree(random, level, blockX, y, blockZ);

--- a/server/src/main/java/org/cloudburstmc/server/level/manager/PopulationChunkManager.java
+++ b/server/src/main/java/org/cloudburstmc/server/level/manager/PopulationChunkManager.java
@@ -55,12 +55,12 @@ public final class PopulationChunkManager implements ChunkManager {
 
     @Override
     public BlockState getBlockState(int x, int y, int z) {
-        return this.chunkFromBlock(x, z).getBlock(x & 0xF, y, z & 0xF, 0);
+        return this.chunkFromBlock(x, z).getBlockState(x & 0xF, y, z & 0xF, 0);
     }
 
     @Override
     public BlockState getBlockState(int x, int y, int z, int layer) {
-        return this.chunkFromBlock(x, z).getBlock(x & 0xF, y, z & 0xF, layer);
+        return this.chunkFromBlock(x, z).getBlockState(x & 0xF, y, z & 0xF, layer);
     }
 
     // TODO
@@ -76,13 +76,13 @@ public final class PopulationChunkManager implements ChunkManager {
 
     @Override
     public boolean setBlockState(int x, int y, int z, BlockState state) {
-        this.chunkFromBlock(x, z).setBlock(x & 0xF, y, z & 0xF, 0, state);
+        this.chunkFromBlock(x, z).setBlockState(x & 0xF, y, z & 0xF, 0, state);
         return true;
     }
 
     @Override
     public boolean setBlockState(int x, int y, int z, int layer, BlockState state) {
-        this.chunkFromBlock(x, z).setBlock(x & 0xF, y, z & 0xF, layer, state);
+        this.chunkFromBlock(x, z).setBlockState(x & 0xF, y, z & 0xF, layer, state);
         return true;
     }
 


### PR DESCRIPTION
Since `getBlock`, `setBlock`, and `getAndSetBlock` are BlockState-related, so their names should include BlockState to make their purpose clearer